### PR TITLE
サンプルのサービスプロバイダーの設定をコメントアウト

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -128,9 +128,9 @@ return [
      | Service Providers$
      |-----------------------------------------------------------------------
      |$
-     */
+     
     'providers' => [
         App\Providers\SampleServiceProvider::class,
     ],
-
+     */
 ];


### PR DESCRIPTION
サービスプロバイダー設定をコメントアウト
理由：エラーが出たため